### PR TITLE
w1-sunxi driver

### DIFF
--- a/linux-sunxi/drivers/w1/Kconfig
+++ b/linux-sunxi/drivers/w1/Kconfig
@@ -25,6 +25,32 @@ config W1_CON
 	  2. Userspace commands. Includes read/write and search/alarm search commands.
 	  3. Replies to userspace commands.
 
+config W1_SUNXI
+    depends on GPIO_SUNXI && W1_MASTER_GPIO
+    tristate "1-wire sunxi support"
+    default n
+    --- help ---
+	This adds a way to register a platform device for 1-wire bus.
+	It introduces a new section "[w1_para]" in the FEX to configure the
+	GPIO pin number used for the bus, with the attribute named "gpio".
+	The GPIO pin must also be defined in the "[gpio_para]" section.
+
+	1-wire device can then be accessed using the w1-gpio driver.
+
+	Example configuration :
+	[w1_para]
+	gpio = 3
+
+	[gpio_para]
+	gpio_used = 1
+	gpio_num = 3
+	...
+	gpio_pin_3 = port:PH7<0><default><default><0>
+
+	It is also possible to configure the GPIO pin number with the
+	module paramerer "gpio". In this case, if the pin is valid,
+	it will be used instead of what is configured in the FEX script.
+	
 source drivers/w1/masters/Kconfig
 source drivers/w1/slaves/Kconfig
 

--- a/linux-sunxi/drivers/w1/Makefile
+++ b/linux-sunxi/drivers/w1/Makefile
@@ -3,6 +3,7 @@
 #
 
 obj-$(CONFIG_W1)	+= wire.o
+obj-$(CONFIG_W1_SUNXI)  += w1_sunxi.o
 wire-objs		:= w1.o w1_int.o w1_family.o w1_netlink.o w1_io.o
 
 obj-y			+= masters/ slaves/

--- a/linux-sunxi/drivers/w1/README.md
+++ b/linux-sunxi/drivers/w1/README.md
@@ -1,0 +1,10 @@
+For 1-Wire w1-gpio driver use w1-sunxi module.
+
+You need to add the following section to your sys_config.fex
+Then rebuild it with u-boot and flash to the device.
+You may need to change the w1_gpio port definition according to your need.
+
+[w1_para]
+w1_used              = 1
+; This is 1W pin for Banana Pi M2 located on 40 pins connector 
+w1_gpio              = port:PM02<1><default><default><default>

--- a/linux-sunxi/drivers/w1/w1_sunxi.c
+++ b/linux-sunxi/drivers/w1/w1_sunxi.c
@@ -89,5 +89,5 @@ module_init(w1_sunxi_init);
 module_exit(w1_sunxi_exit);
 
 MODULE_DESCRIPTION("GPIO w1 sunxi platform device based on Damien Nicolet <zardam@gmail.com> work.");
-MODULE_AUTHOR("Grzegorz Rajtar <mcrgegor@blackmesaeast.com.pl>");
+MODULE_AUTHOR("Grzegorz Rajtar <mcgregor@blackmesaeast.com.pl>");
 MODULE_LICENSE("GPL");

--- a/linux-sunxi/drivers/w1/w1_sunxi.c
+++ b/linux-sunxi/drivers/w1/w1_sunxi.c
@@ -1,0 +1,93 @@
+#include <linux/device.h>
+#include <linux/module.h>
+#include <linux/w1-gpio.h>
+#include <linux/platform_device.h>
+#include <linux/gpio.h>
+#include <mach/sys_config.h>
+
+static int gpiochip = -1;
+module_param(gpiochip, int, 0444);
+MODULE_PARM_DESC(gpiochip, "w1 gpio lowlevel number");
+
+static struct platform_device *w1_device;
+
+static int __init w1_sunxi_init(void)
+{
+	int ret = 0;
+	struct w1_gpio_platform_data w1_gpio_pdata = {
+		.pin = gpiochip,
+		.is_open_drain = 0,
+	};
+
+	if (!gpio_is_valid(w1_gpio_pdata.pin)) {	
+
+		script_item_u val;
+		script_item_value_type_e type;
+		script_item_u *list = NULL;
+		int idx;
+		int cnt;
+
+		if (gpiochip == -1 ) {
+			type = script_get_item("w1_para", "w1_gpio", &val);
+			if  (type == SCIRPT_ITEM_VALUE_TYPE_PIO) {
+				cnt = script_get_pio_list("w1_para", &list);
+
+				for (idx = 0; idx < cnt; idx++)
+					gpio_request(list[idx].gpio.gpio, NULL);
+		
+				sw_gpio_setall_range(&list[0].gpio, cnt);
+
+				for (idx = 0; idx < cnt; idx++) {
+					gpio_free(list[idx].gpio.gpio);
+					gpiochip = list[idx].gpio.gpio;
+				}
+				ret = 0;
+			} else {
+				ret = 1;
+			}
+		}
+
+		printk(KERN_INFO "w1_sunxi_init gpiochip:%d\n", gpiochip);
+		
+		if (ret || !gpio_is_valid(gpiochip)) {
+			pr_err("invalid gpio pin in fex configuration : %d\n",
+			       gpiochip);
+			return -EINVAL;
+		}
+		w1_gpio_pdata.pin = gpiochip;
+	}
+
+	gpio_free(w1_gpio_pdata.pin);
+	w1_device = platform_device_alloc("w1-gpio", 0);
+
+	if (!w1_device)
+		return -ENOMEM;
+
+	ret =
+	    platform_device_add_data(w1_device, &w1_gpio_pdata,
+				     sizeof(struct w1_gpio_platform_data));
+	if (ret)
+		goto err;
+
+	ret = platform_device_add(w1_device);
+	if (ret)
+		goto err;
+
+	return 0;
+
+err:
+	platform_device_put(w1_device);
+	return ret;
+}
+
+static void __exit w1_sunxi_exit(void)
+{
+	platform_device_unregister(w1_device);
+}
+
+module_init(w1_sunxi_init);
+module_exit(w1_sunxi_exit);
+
+MODULE_DESCRIPTION("GPIO w1 sunxi platform device based on Damien Nicolet <zardam@gmail.com> work.");
+MODULE_AUTHOR("Grzegorz Rajtar <mcrgegor@blackmesaeast.com.pl>");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Based on Damien Nicolet zardam@gmail.com work  I have created w1-sunxi driver that works with w1-gpio module. All you need to do is to add w1_para section to sys_config.fex. I have tested it with my
Banana PI M2 board and DS18B20 temperature sensor. The sensor need's a 4K7 pullup resistor between DQ nad VDD pin.

```
[w1_para]
w1_used              = 1
; This is 1W pin for Banana Pi M2 located on 40 pins connector 
w1_gpio              = port:PM02<1><default><default><default>
```
